### PR TITLE
Add keywords for indexing on npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "thanc",
     "thank",
     "thanks",
+    "thx",
+    "thanx",
     "star",
     "stars",
     "open source",

--- a/package.json
+++ b/package.json
@@ -37,5 +37,23 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-minify": "^0.2.0"
-  }
+  },
+  "keywords": [
+    "thanc",
+    "thank",
+    "thanks",
+    "star",
+    "stars",
+    "open source",
+    "sustainability",
+    "donate",
+    "support",
+    "funding",
+    "patreon",
+    "donor",
+    "thank you",
+    "fund",
+    "sustain",
+    "earn"
+  ]
 }


### PR DESCRIPTION
Without the `keywords` field inside the `package.json` the package cannot be found easily from users.